### PR TITLE
Update main.yml to specify fixed bundler version

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -51,5 +51,6 @@
   gem:
     name=bundler
     user_install=no
+    version=1.17.3  
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
* 元のままだと bundler 2.0.2 がインストールされて、その後いろいろと問題がおこる
* bundler 1.17.3 をインストールするようにした
* vagrant ubuntsu/xenial64 と kagoya VPS(KVM) ubuntu 16.04 で確認済
