### PR TITLE
redmine4.0対応（ubuntu18.04）

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 
 ## システム構成
 
-* Redmine 3.4
-* Ubuntu Server 16.04.2 LTS
+* Redmine 4.0
+* Ubuntu Server 18.04.3 LTS
 * PostgreSQL
 * Apache
 
 
 ## Redmineのインストール手順
 
-インストール直後の Ubuntu 16.04 にログインし以下の操作を行ってください。
+インストール直後の Ubuntu 18.04 にログインし以下の操作を行ってください。
 
 
 ### Ansibleとgitのインストール

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 * Ubuntu Server 18.04.3 LTS
 * PostgreSQL
 * Apache
-* Docker
 
 
 ## Redmineのインストール手順
@@ -31,8 +30,11 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ### Ansibleとgitのインストール
 
 ```
+sudo apt-get update
+====== Dockerの場合=====
 apt-get update
 apt-get install -y sudo
+========================
 sudo apt-get install -y python-pip libpython-dev git libssl-dev iproute2
 sudo pip install ansible\==2.8.5
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 * Ubuntu Server 18.04.3 LTS
 * PostgreSQL
 * Apache
+* Docker
 
 
 ## Redmineのインストール手順
@@ -30,8 +31,9 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ### Ansibleとgitのインストール
 
 ```
-sudo apt-get update
-sudo apt-get install -y python-pip libpython-dev git libssl-dev
+apt-get update
+apt-get install -y sudo
+sudo apt-get install -y python-pip libpython-dev git libssl-dev iproute2
 sudo pip install ansible\==2.8.5
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 
 ## システム構成
 
+* Ansible 2.8.5
 * Redmine 4.0
 * Ubuntu Server 18.04.3 LTS
 * PostgreSQL
@@ -31,7 +32,7 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ```
 sudo apt-get update
 sudo apt-get install -y python-pip libpython-dev git libssl-dev
-sudo pip install ansible
+sudo pip install ansible\==2.8.5
 ```
 
 ### playbookのダウンロード

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -16,6 +16,9 @@ redmine_dir_group: www-data
 # Redmineで使用する日本語フォントファイル
 redmine_font_path: /usr/share/fonts/truetype/takao-gothic/TakaoPGothic.ttf
 
+# Redmineで使用するlocale
+redmine_locale: ja_JP.UTF-8
+
 # ダウンロードするRubyのソースコード
 ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.6
 ruby_archive_version: ruby-2.6.5

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -4,7 +4,7 @@ db_passwd_redmine: Must_be_changed!
 # ----------------------------------------------------------------------
 
 # Redmineのチェックアウト元URL
-redmine_svn_url: http://svn.redmine.org/redmine/branches/3.4-stable
+redmine_svn_url: http://svn.redmine.org/redmine/branches/4.0-stable
 
 # Redmineのデプロイ先ディレクトリ
 redmine_dir: /var/lib/redmine
@@ -17,8 +17,8 @@ redmine_dir_group: www-data
 redmine_font_path: /usr/share/fonts/truetype/takao-gothic/TakaoPGothic.ttf
 
 # ダウンロードするRubyのソースコード
-ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.4
-ruby_archive_version: ruby-2.4.1
+ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.6
+ruby_archive_version: ruby-2.6.5
 ruby_archive_ext: tar.bz2
 ruby_archive_name: "{{ ruby_archive_version }}.{{ ruby_archive_ext }}"
 

--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -18,6 +18,6 @@
   postgresql_db:
     name=redmine
     encoding='UTF-8'
-    lc_collate='ja_JP.UTF-8'
-    lc_ctype='ja_JP.UTF-8'
+    lc_collate= {{redmine_locale }}
+    lc_ctype= {{redmine_locale }}
     template='template0'

--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: start postgresql server
+  become: yes
+  become_user: postgres
+  service:
+    name=postgresql
+    state=started
+
 - name: PostgreSQL ユーザー作成
   become: yes
   become_user: postgres

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -51,5 +51,6 @@
   gem:
     name=bundler
     user_install=no
+    version=1.17.3
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -16,10 +16,12 @@
     name='postgresql,postgresql-server-dev-10,python-psycopg2'
 
 - name: create locale ja_JP.UTF-8
+  become: yes
   locale_gen:
     name: "{{ redmine_locale }}"
 
 - name: set locale to ja_JP.UTF-8
+  become: yes
   command: update-locale LANG={{ redmine_locale }}
   when: ansible_env.LANG | default('') != "{{ redmine_locale }}"
 

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -13,7 +13,7 @@
 - name:  PostgreSQLとヘッダファイルのインストール
   become: yes
   apt:
-    name='postgresql,postgresql-server-dev-9.5,python-psycopg2'
+    name='postgresql,postgresql-server-dev-10,python-psycopg2'
 
 - name: create locale ja_JP.UTF-8
   locale_gen:

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -1,9 +1,4 @@
 # PostgreSQLでlc_collateとlc_ctypeに ja_JP.UTF-8 を指定するために必要
-- name: ja_JP.UTF-8ロケール作成
-  become: yes
-  command:
-    locale-gen ja_JP.UTF-8
-
 - name: apt-get update
   become: yes
   apt:
@@ -19,6 +14,14 @@
   become: yes
   apt:
     name='postgresql,postgresql-server-dev-9.5,python-psycopg2'
+
+- name: create locale ja_JP.UTF-8
+  locale_gen:
+    name: "{{ redmine_locale }}"
+
+- name: set locale to ja_JP.UTF-8
+  command: update-locale LANG={{ redmine_locale }}
+  when: ansible_env.LANG | default('') != "{{ redmine_locale }}"
 
 - name:  Apacheとヘッダファイルのインストール
   become: yes


### PR DESCRIPTION
redmine4.0対応の変更です。
以下ご確認よろしくお願いいたします。

* redmine4.0, ruby2.6, ubuntu18.04, postgreSQL10 対応
* 現状のコードではja_JP.UTF-8ロケールが作成できなかったため、設定方法を変更
* postgreSQL 起動処理がなくPostgreSQLユーザー作成時にエラーが出力されたため、起動処理を追加
* bundler2.0.1では動作しなかったため、1.17.3バージョンを指定
