### PR TITLE
redmine4.2対応（ubuntu20.04）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:20.04
     steps:
       - run:
           name: Setup
           command: |
             apt-get update
-            apt-get install -y sudo iproute2
-            sudo apt-get install -y python-pip libpython-dev git libssl-dev
-            sudo pip install ansible\==2.8.5
+            apt-get install -y sudo iproute2 libpq-dev gcc
+            sudo apt-get install -y python3-pip libpython2-dev git libssl-dev
+            sudo pip install ansible\==5.7.0 psycopg2
       - checkout
       - run:
           name: Execute ansible playbook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
           name: Setup
           command: |
             apt-get update
-            apt-get install -y sudo iproute2 libpq-dev gcc
-            sudo apt-get install -y python3-pip libpython2-dev git libssl-dev
+            apt-get install -y sudo iproute2
+            sudo apt-get install -y python3-pip libpython2-dev git libssl-dev libpq-dev gcc
             sudo pip install ansible\==5.7.0 psycopg2
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ sudo apt-get update
 
 ========== Dockerの場合=========
 apt-get update
-apt-get install -y sudo iproute2 libpq-dev gcc
+apt-get install -y sudo iproute2
 ================================
 
-sudo apt-get install -y python3-pip libpython2-dev git libssl-dev
+sudo apt-get install -y python3-pip libpython2-dev git libssl-dev libpq-dev gcc
 sudo pip install ansible\==5.7.0 psycopg2
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@
 
 Ansibleを使ってRedmineを自動インストールするためのプレイブックです。以下のwebサイトで紹介されている手順におおむね準拠しています。
 
-[Redmine 3.4をUbuntu Server 16.04.2 LTSにインストールする手順](http://blog.redmine.jp/articles/3_4/install/ubuntu/)
+[Redmine 4.2をUbuntu 20.04 LTSにインストールする手順](https://blog.redmine.jp/articles/4_2/install/ubuntu/)
 
 
 ## システム構成
 
-* Ansible 2.8.5
-* Redmine 4.0
-* Ubuntu Server 18.04.3 LTS
+* Ansible 5.7.0
+* Redmine 4.2
+* Ubuntu Server 20.04.4 LTS
 * PostgreSQL
 * Apache
 
 
 ## Redmineのインストール手順
 
-インストール直後の Ubuntu 18.04 にログインし以下の操作を行ってください。
+インストール直後の Ubuntu 20.04 にログインし以下の操作を行ってください。
 
 
 ### Ansibleとgitのインストール
@@ -34,11 +34,11 @@ sudo apt-get update
 
 ========== Dockerの場合=========
 apt-get update
-apt-get install -y sudo iproute2
+apt-get install -y sudo iproute2 libpq-dev gcc
 ================================
 
-sudo apt-get install -y python-pip libpython-dev git libssl-dev
-sudo pip install ansible\==2.8.5
+sudo apt-get install -y python3-pip libpython2-dev git libssl-dev
+sudo pip install ansible\==5.7.0 psycopg2
 ```
 
 ### playbookのダウンロード

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -4,7 +4,7 @@ db_passwd_redmine: Must_be_changed!
 # ----------------------------------------------------------------------
 
 # Redmineのチェックアウト元URL
-redmine_svn_url: http://svn.redmine.org/redmine/branches/4.0-stable
+redmine_svn_url: http://svn.redmine.org/redmine/branches/4.2-stable
 
 # Redmineのデプロイ先ディレクトリ
 redmine_dir: /var/lib/redmine
@@ -20,9 +20,9 @@ redmine_font_path: /usr/share/fonts/truetype/takao-gothic/TakaoPGothic.ttf
 redmine_locale: ja_JP.UTF-8
 
 # ダウンロードするRubyのソースコード
-ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.6
-ruby_archive_version: ruby-2.6.5
-ruby_archive_ext: tar.bz2
+ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.7
+ruby_archive_version: ruby-2.7.4
+ruby_archive_ext: tar.gz
 ruby_archive_name: "{{ ruby_archive_version }}.{{ ruby_archive_ext }}"
 
 ruby_file_name: /usr/local/bin/ruby

--- a/roles/apache/templates/redmine.conf
+++ b/roles/apache/templates/redmine.conf
@@ -1,4 +1,6 @@
 <Directory "{{ redmine_dir }}/public">
+  Allow from all
+  Options -MultiViews
   Require all granted
 </Directory>
 

--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -4,6 +4,18 @@
     name=postgresql
     state=started
 
+- name: posgresユーザになるためACLがインストールされているか確認
+  stat:
+    path: /usr/local/bin/acl
+  register:
+    result
+
+- name: ACLインストール
+  become: yes
+  apt:
+    name='acl'
+  when: not result.stat.exists
+
 - name: PostgreSQL ユーザー作成
   become: yes
   become_user: postgres

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -13,7 +13,7 @@
 - name:  PostgreSQLとヘッダファイルのインストール
   become: yes
   apt:
-    name='postgresql,postgresql-server-dev-10,python-psycopg2'
+    name='postgresql,libpq-dev'
 
 - name: create locale ja_JP.UTF-8
   become: yes
@@ -28,12 +28,12 @@
 - name:  Apacheとヘッダファイルのインストール
   become: yes
   apt:
-    name='apache2,apache2-dev,libapr1-dev,libaprutil1-dev'
+    name='apache2,apache2-dev'
 
 - name:  ImageMagickとヘッダファイル・日本語フォントのインストール
   become: yes
   apt:
-    name='imagemagick,libmagick++-dev,fonts-takao-pgothic'
+    name='imagemagick,fonts-takao-pgothic'
 
 - name:  そのほかのツールのインストール
   become: yes


### PR DESCRIPTION
こんにちは。Playbook の公開ありがとうございます。最近 Redmine をインストールする際に使わせていただきました。
Redmine4.2 向けに内容更新しましたので、もしよければレビューいただけますでしょうか。


## 変更点
1. ライブラリのアップデート

1. PosgtreSQLユーザー作成に必要なパッケージを追加
    * `psycopg2`
    * `libpq-dev` と `gcc` （コンテナ環境のみ, psycopg2のビルドに必要）
    * `acl`


## 検証
- [x] VM 上の Ubuntu 20.04.4 LTS にて Redmine の画面が表示されること
- [x] CircleCI にてビルドが通ること