### PR TITLE
Redmine 5.1 + Ubuntu 24.04 に対応する（ CI を除く）

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ### Ansibleとgitのインストール
 
 ```
-sudo apt-get update
+sudo apt update
 
 ========== Dockerの場合=========
 apt-get update
 apt-get install -y sudo iproute2
 ================================
 
-sudo apt-get install -y python3-pip libpython2-dev git libssl-dev libpq-dev gcc
-sudo pip install ansible\==5.7.0 psycopg2
+sudo apt install -y ansible-core libpython3-dev python3-psycopg2 git libssl-dev libpq-dev gcc
+
 ```
 
 ### playbookのダウンロード

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ apt-get update
 apt-get install -y sudo iproute2
 ================================
 
-sudo apt install -y ansible-core libpython3-dev python3-psycopg2 git libssl-dev libpq-dev gcc
+sudo apt install -y ansible-core libpython3-dev python3-psycopg2 git libssl-dev libpq-dev gcc language-pack-ja
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 
 ## システム構成
 
-* Ansible 5.7.0
+* Ansible 2.17.5
 * Redmine 5.1
 * Ubuntu Server 24.04 LTS
 * PostgreSQL
@@ -25,12 +25,22 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 インストール直後の Ubuntu Server にログインし以下の操作を行ってください。
 
 
-### Ansibleとgitのインストール
+### Ansibleと必要パッケージのインストール
 
-```
+[Installing Ansible on specific operating systems — Ansible Community Documentation](https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-ubuntu) を参考にして Ansible をインストールします。
+
+```bash
 sudo apt update
-sudo apt install -y python3-psycopg2 ansible-core git libssl-dev libpq-dev gcc
-# 途中でタイムゾーンの設定が求められるため適切な地域を選択してください
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
+sudo apt install ansible
+```
+
+git や [PostgreSQL の操作](https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_db_module.html) で必要なパッケージをインストールします。
+
+```bash
+sudo apt update
+sudo apt install git python3-psycopg2
 ```
 
 ### playbookのダウンロード
@@ -47,10 +57,13 @@ git clone https://github.com/farend/redmine-ubuntu-ansible.git
 
 下記コマンドを実行してください。Redmineの自動インストールが開始されます。
 
+> [!NOTE]
+>
+> "BECOME password"にsudoを実行するためのパスワードを入力してください。
+
 ```
 cd redmine-ubuntu-ansible
 ansible-playbook -K -i hosts site.yml
-==> "BECOME password"にsudoを実行するためのパスワードを入力してください。
 ```
 
 10〜20分ほどでインストールが完了します。webブラウザで `http://サーバIPアドレス/redmine` にアクセスしてください。Redmineの画面が表示されるはずです。

--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ## システム構成
 
 * Ansible 5.7.0
-* Redmine 4.2
-* Ubuntu Server 20.04.4 LTS
+* Redmine 5.1
+* Ubuntu Server 24.04 LTS
 * PostgreSQL
 * Apache
 
-
 ## Redmineのインストール手順
 
-インストール直後の Ubuntu 20.04 にログインし以下の操作を行ってください。
+インストール直後の Ubuntu Server にログインし以下の操作を行ってください。
 
 
 ### Ansibleとgitのインストール
@@ -37,8 +36,8 @@ apt-get update
 apt-get install -y sudo iproute2
 ================================
 
-sudo apt install -y ansible-core libpython3-dev python3-psycopg2 git libssl-dev libpq-dev gcc language-pack-ja
-
+sudo apt install -y python3-pip libpython2-dev git libssl-dev libpq-dev gcc
+sudo pip install ansible psycopg2
 ```
 
 ### playbookのダウンロード

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 
 Ansibleを使ってRedmineを自動インストールするためのプレイブックです。以下のwebサイトで紹介されている手順におおむね準拠しています。
 
-[Redmine 4.2をUbuntu 20.04 LTSにインストールする手順](https://blog.redmine.jp/articles/4_2/install/ubuntu/)
-
+[Redmine 5.1 をUbuntu 24.04 LTSにインストールする手順](https://blog.redmine.jp/articles/5_1/install/ubuntu24/)
 
 ## システム構成
 
@@ -30,14 +29,8 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 
 ```
 sudo apt update
-
-========== Dockerの場合=========
-apt-get update
-apt-get install -y sudo iproute2
-================================
-
-sudo apt install -y python3-pip libpython2-dev git libssl-dev libpq-dev gcc
-sudo pip install ansible psycopg2
+sudo apt install -y python3-psycopg2 ansible-core git libssl-dev libpq-dev gcc
+# 途中でタイムゾーンの設定が求められるため適切な地域を選択してください
 ```
 
 ### playbookのダウンロード

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -4,7 +4,7 @@ db_passwd_redmine: Must_be_changed!
 # ----------------------------------------------------------------------
 
 # Redmineのチェックアウト元URL
-redmine_svn_url: http://svn.redmine.org/redmine/branches/4.2-stable
+redmine_svn_url: https://svn.redmine.org/redmine/branches/5.1-stable
 
 # Redmineのデプロイ先ディレクトリ
 redmine_dir: /var/lib/redmine
@@ -20,8 +20,8 @@ redmine_font_path: /usr/share/fonts/truetype/takao-gothic/TakaoPGothic.ttf
 redmine_locale: ja_JP.UTF-8
 
 # ダウンロードするRubyのソースコード
-ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/2.7
-ruby_archive_version: ruby-2.7.4
+ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/3.2
+ruby_archive_version: ruby-3.2.4
 ruby_archive_ext: tar.gz
 ruby_archive_name: "{{ ruby_archive_version }}.{{ ruby_archive_ext }}"
 

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -16,8 +16,10 @@ redmine_dir_group: www-data
 # Redmineで使用する日本語フォントファイル
 redmine_font_path: /usr/share/fonts/truetype/takao-gothic/TakaoPGothic.ttf
 
-# Redmineで使用するlocale
-redmine_locale: ja_JP.UTF-8
+# Redmine DB で使用する設定
+redmine_db_name: redmine
+redmine_db_user: redmine
+redmine_db_locale: ja_JP.UTF-8
 
 # ダウンロードするRubyのソースコード
 ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/3.2

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -6,22 +6,13 @@
     group: "{{ redmine_dir_group }}"
     recurse: yes
 
-- name: Passengerがインストールされているか確認
+- name: PassengerのApache用設定ファイルが存在するか確認
   command:
-    test -f /usr/local/bin/passenger-install-apache2-module
+    test -f /etc/apache2/conf-available/redmine.conf
   register:
     result
   failed_when: result.rc not in [0, 1]
   changed_when: false
-
-- name: Passengerをインストール
-  become: yes
-  gem:
-    name=passenger
-    user_install=no
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-  when: result.rc == 1
 
 - name: PassengerのApache用モジュールのインストール
   become: yes

--- a/roles/apache/templates/redmine.conf
+++ b/roles/apache/templates/redmine.conf
@@ -4,10 +4,10 @@
   Require all granted
 </Directory>
 
-Alias /redmine /var/lib/redmine/public
+Alias /redmine {{ redmine_dir }}/public
 <Location /redmine>
   PassengerBaseURI /redmine
-  PassengerAppRoot /var/lib/redmine
+  PassengerAppRoot {{ redmine_dir }}
 </Location>
 
 {{ passenger_snippet_vars.stdout }}

--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -13,22 +13,22 @@
 - name: ACLインストール
   become: yes
   apt:
-    name='acl'
+    name: "acl"
   when: not result.stat.exists
 
 - name: PostgreSQL ユーザー作成
   become: yes
   become_user: postgres
   postgresql_user:
-    name=redmine
-    password={{ db_passwd_redmine }}
+    name: "redmine"
+    password: "{{ db_passwd_redmine }}"
 
 - name: PostgreSQL データベース作成
   become: yes
   become_user: postgres
   postgresql_db:
-    name=redmine
-    encoding='UTF-8'
-    lc_collate= {{redmine_locale }}
-    lc_ctype= {{redmine_locale }}
-    template='template0'
+    name: "redmine"
+    encoding: "UTF-8"
+    lc_collate: "{{ redmine_locale }}"
+    lc_ctype: "{{ redmine_locale }}"
+    template: "template0"

--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -20,15 +20,16 @@
   become: yes
   become_user: postgres
   postgresql_user:
-    name: "redmine"
+    name: "{{ redmine_db_user }}"
     password: "{{ db_passwd_redmine }}"
 
 - name: PostgreSQL データベース作成
   become: yes
   become_user: postgres
   postgresql_db:
-    name: "redmine"
+    name: "{{ redmine_db_name }}"
+    owner: "{{ redmine_db_user }}"
     encoding: "UTF-8"
-    lc_collate: "{{ redmine_locale }}"
-    lc_ctype: "{{ redmine_locale }}"
+    lc_collate: "{{ redmine_db_locale }}"
+    lc_ctype: "{{ redmine_db_locale }}"
     template: "template0"

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -1,11 +1,22 @@
+- name: mkdir /var/lib/redmine
+  become: yes
+  command:
+    mkdir /var/lib/redmine
+
+- name: chown www-data /var/lib/redmine
+  become: yes
+  command:
+   chown www-data /var/lib/redmine
+
 - name: Redmineのソースコードをチェックアウト
   become: yes
-  subversion:
-    repo={{ redmine_svn_url }}
-    dest={{ redmine_dir }}
+  become_user: www-data
+  command:
+    svn co https://svn.redmine.org/redmine/branches/5.1-stable /var/lib/redmine
 
 - name: database.ymlの作成
   become: yes
+  become_user: www-data
   template:
     src=database.yml
     dest={{ redmine_dir }}/config/database.yml
@@ -15,6 +26,7 @@
 
 - name: configuration.ymlの作成
   become: yes
+  become_user: www-data
   template:
     src=configuration.yml
     dest={{ redmine_dir }}/config/configuration.yml
@@ -50,6 +62,7 @@
 
 - name: secret tokenの作成
   become: yes
+  become_user: www-data
   command:
     bundle exec rake generate_secret_token
     chdir={{ redmine_dir }}
@@ -59,6 +72,7 @@
 
 - name: データベースのマイグレーション
   become: yes
+  become_user: www-data
   command:
     bundle exec rake db:migrate
     chdir={{ redmine_dir }}

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -1,22 +1,22 @@
 - name: mkdir /var/lib/redmine
   become: yes
   command:
-    mkdir /var/lib/redmine
+    mkdir -p {{ redmine_dir }}
 
 - name: chown www-data /var/lib/redmine
   become: yes
   command:
-   chown www-data /var/lib/redmine
+   chown {{ redmine_dir_owner }} {{ redmine_dir }}
 
 - name: Redmineのソースコードをチェックアウト
   become: yes
-  become_user: www-data
+  become_user: "{{ redmine_dir_owner }}"
   command:
-    svn co https://svn.redmine.org/redmine/branches/5.1-stable /var/lib/redmine
+    svn co {{ redmine_svn_url }} {{ redmine_dir }}
 
 - name: database.ymlの作成
   become: yes
-  become_user: www-data
+  become_user: "{{ redmine_dir_owner }}"
   template:
     src=database.yml
     dest={{ redmine_dir }}/config/database.yml
@@ -26,7 +26,7 @@
 
 - name: configuration.ymlの作成
   become: yes
-  become_user: www-data
+  become_user: "{{ redmine_dir_owner }}"
   template:
     src=configuration.yml
     dest={{ redmine_dir }}/config/configuration.yml
@@ -40,10 +40,30 @@
   failed_when: result_test_gemfile.rc not in [0, 1]
   changed_when: false
 
-- name: gemsパッケージのインストール
+- name: gemsパッケージのインストール 1/3
+  become: yes
+  become_user: "{{ redmine_dir_owner }}"
+  template:
+    src=Gemfile.local
+    dest={{ redmine_dir }}/Gemfile.local
+    force=no
+  when:
+    result_test_gemfile.rc == 1
+
+- name: gemsパッケージのインストール 2/3
   become: yes
   command:
-    bundle install --path vendor/bundle
+    bundle config set --local without 'development test'
+    chdir={{ redmine_dir }}
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+  when:
+    result_test_gemfile.rc == 1
+
+- name: gemsパッケージのインストール 3/3
+  become: yes
+  command:
+    bundle install
     chdir={{ redmine_dir }}
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
@@ -62,7 +82,7 @@
 
 - name: secret tokenの作成
   become: yes
-  become_user: www-data
+  become_user: "{{ redmine_dir_owner }}"
   command:
     bundle exec rake generate_secret_token
     chdir={{ redmine_dir }}
@@ -72,7 +92,7 @@
 
 - name: データベースのマイグレーション
   become: yes
-  become_user: www-data
+  become_user: "{{ redmine_dir_owner }}"
   command:
     bundle exec rake db:migrate
     chdir={{ redmine_dir }}

--- a/roles/redmine/templates/Gemfile.local
+++ b/roles/redmine/templates/Gemfile.local
@@ -1,0 +1,1 @@
+gem 'passenger', group: :production

--- a/roles/redmine/templates/database.yml
+++ b/roles/redmine/templates/database.yml
@@ -1,8 +1,8 @@
 production:
   adapter: postgresql
-  database: redmine
+  database: "{{ redmine_db_name }}"
   host: localhost
-  username: redmine
+  username: "{{ redmine_db_user }}"
   password: "{{ db_passwd_redmine }}"
   encoding: utf8
   pool: 5

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -46,11 +46,11 @@
     chdir={{ work_dir }}/{{ ruby_archive_version }}
   when: ruby_test_vars.rc == 1
 
-- name: bundlerのインストール
-  become: yes
-  gem:
-    name=bundler
-    user_install=no
-    version=1.17.3
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+#- name: bundlerのインストール
+#  become: yes
+#  gem:
+#    name=bundler
+#    user_install=no
+#    version=1.17.3
+#  environment:
+#    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -45,12 +45,3 @@
     make install
     chdir={{ work_dir }}/{{ ruby_archive_version }}
   when: ruby_test_vars.rc == 1
-
-#- name: bundlerのインストール
-#  become: yes
-#  gem:
-#    name=bundler
-#    user_install=no
-#    version=1.17.3
-#  environment:
-#    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -1,5 +1,5 @@
 # PostgreSQLでlc_collateとlc_ctypeに ja_JP.UTF-8 を指定するために必要
-- name: apt-get update
+- name: apt update
   become: yes
   apt:
     update_cache=yes
@@ -15,15 +15,18 @@
   apt:
     name='postgresql,libpq-dev'
 
-- name: create locale ja_JP.UTF-8
+- name: Install 'language-pack-ja' and create locale ja_JP.UTF-8
   become: yes
-  locale_gen:
-    name: "{{ redmine_locale }}"
+  apt:
+    name='language-pack-ja-base language-pack-ja'
 
 - name: set locale to ja_JP.UTF-8
   become: yes
-  command: update-locale LANG={{ redmine_locale }}
-  when: ansible_env.LANG | default('') != [ redmine_locale ]
+  command: localectl set-locale LANG={{ redmine_locale }}
+
+- name: source /etc/default/locale
+  become: yes
+  command: source /etc/default/locale
 
 - name:  Apacheとヘッダファイルのインストール
   become: yes

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -15,18 +15,9 @@
   apt:
     name='postgresql,libpq-dev'
 
-- name: Install 'language-pack-ja' and create locale ja_JP.UTF-8
-  become: yes
-  apt:
-    name='language-pack-ja-base language-pack-ja'
-
 - name: set locale to ja_JP.UTF-8
   become: yes
   command: localectl set-locale LANG={{ redmine_locale }}
-
-- name: source /etc/default/locale
-  become: yes
-  command: source /etc/default/locale
 
 - name:  Apacheとヘッダファイルのインストール
   become: yes

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -4,7 +4,15 @@
   apt:
     update_cache=yes
     cache_valid_time=86400
+- name: set locale to ja_JP.UTF-8 1/2
+  become: yes
+  apt:
+    name='locales'
+- name: set locale to ja_JP.UTF-8 2/2
+  become: yes
+  command: localectl set-locale LANG={{ redmine_db_locale }}
 
+# Redmine を動かすために必要なパッケージのインストール
 - name: RubyとPassengerのビルドに必要な開発ツールやヘッダファイルのインストール
   become: yes
   apt:
@@ -14,21 +22,6 @@
   become: yes
   apt:
     name='postgresql,libpq-dev'
-
-- name: Generate ja_JP.UTF-8 locale
-  become: yes
-  command: locale-gen ja_JP.UTF-8
-
-- name: Update system locale to ja_JP.UTF-8
-  become: yes
-  command: update-locale LANG=ja_JP.UTF-8
-
-- name: Ensure locale is set in /etc/default/locale
-  become: yes
-  lineinfile:
-    path: /etc/default/locale
-    line: 'LANG=ja_JP.UTF-8'
-    create: yes
 
 - name:  Apacheとヘッダファイルのインストール
   become: yes

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -15,9 +15,20 @@
   apt:
     name='postgresql,libpq-dev'
 
-- name: set locale to ja_JP.UTF-8
+- name: Generate ja_JP.UTF-8 locale
   become: yes
-  command: localectl set-locale LANG={{ redmine_locale }}
+  command: locale-gen ja_JP.UTF-8
+
+- name: Update system locale to ja_JP.UTF-8
+  become: yes
+  command: update-locale LANG=ja_JP.UTF-8
+
+- name: Ensure locale is set in /etc/default/locale
+  become: yes
+  lineinfile:
+    path: /etc/default/locale
+    line: 'LANG=ja_JP.UTF-8'
+    create: yes
 
 - name:  Apacheとヘッダファイルのインストール
   become: yes


### PR DESCRIPTION
## 概要

#14 で提案予定だったものを参考に、Redmine 5.1 + Ubuntu 24.04 に対応しました。

## 方針

* https://blog.redmine.jp/articles/5_1/install/ubuntu24/ の手順を参考にする
* #14 で修正されているように、Dockerの場合は考慮しない
  * あくまでも README にある通り、最小構成でインストールした Ubuntu Server を対象にする
  * Docker が使える環境であれば ansible ではなくhttps://hub.docker.com/r/redmica/redmica/ や https://hub.docker.com/r/redmica/redmica/ を利用した方が良いと考えました
* Ansible 自体のインストールは pip よりも [Installing Ansible on specific operating systems — Ansible Community Documentation](https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html#installing-ansible-on-ubuntu) に従う
  * CI を考慮していないので問題が発生するかもしれません
* [group_vars/redmine-servers](/group_vars/redmine-servers) にてRedmineの配置先やDB名などを管理できるようにする
  * #14 で部分的に対応していた箇所も併せて管理できるようにする
* 言語設定は後続の処理が依存するため処理順を変更する
* `passenger` の `gem install` は 依存関係でインストールが失敗しないように Gemfile.local で管理する
  * `e.g. rackup's executable "rackup" conflicts with rack`

## 確認したこと

- [x] VirtualBox上に 最小インストールの [Ubuntu Server for ARM](https://ubuntu.com/download/server/arm) を用意して、Ansible を使って Redmine 5.1 を自動インストールできること
<img width="905" alt="redmine51-ubuntu24" src="https://github.com/user-attachments/assets/2d449ed3-8f77-4269-b911-a757abb93c29">
