### PR TITLE
Redmine 6.0 に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ansibleを使ってRedmineを自動インストールするためのプレイブ
 ## システム構成
 
 * Ansible 2.17.5
-* Redmine 5.1
+* Redmine 6.0
 * Ubuntu Server 24.04 LTS
 * PostgreSQL
 * Apache

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -3,8 +3,11 @@
 db_passwd_redmine: Must_be_changed!
 # ----------------------------------------------------------------------
 
+# Redmineにアクセスするときのサブディレクトリ名
+redmine_relative_url_root: /redmine
+
 # Redmineのチェックアウト元URL
-redmine_svn_url: https://svn.redmine.org/redmine/branches/5.1-stable
+redmine_svn_url: https://svn.redmine.org/redmine/branches/6.0-stable
 
 # Redmineのデプロイ先ディレクトリ
 redmine_dir: /var/lib/redmine

--- a/roles/apache/templates/redmine.conf
+++ b/roles/apache/templates/redmine.conf
@@ -4,9 +4,9 @@
   Require all granted
 </Directory>
 
-Alias /redmine {{ redmine_dir }}/public
-<Location /redmine>
-  PassengerBaseURI /redmine
+Alias {{ redmine_relative_url_root }} {{ redmine_dir }}/public
+<Location {{ redmine_relative_url_root }}>
+  PassengerBaseURI {{ redmine_relative_url_root }}
   PassengerAppRoot {{ redmine_dir }}
 </Location>
 

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -112,11 +112,14 @@
   when:
     result_database_yml is changed
 
-- name: farend_basicテーマのダウンロード
+- name: farend_basicテーマのダウンロードと展開
   become: yes
-  git:
-    repo=https://github.com/farend/redmine_theme_farend_basic.git
-    dest={{ redmine_dir }}/public/themes/farend_basic
+  shell: |
+    wget -O {{ work_dir }}/farend_basic.tar.gz https://github.com/farend/redmine_theme_farend_basic/archive/refs/tags/1.5.tar.gz
+    mkdir -p {{ redmine_dir }}/themes/farend_basic
+    tar xzf {{ work_dir }}/farend_basic.tar.gz -C {{ redmine_dir }}/themes/farend_basic --strip-components=1
+  when:
+    result_database_yml is changed
 
 - name: テーマをfarend_basicに切り替え
   become: yes
@@ -172,3 +175,13 @@
     RAILS_ENV: production
   when:
     result_database_yml is changed
+
+- name: CSS や JavaScript、画像などを public/assets ディレクトリ配置
+  become: yes
+  command:
+    bundle exec rake assets:clobber assets:precompile
+    chdir={{ redmine_dir }}
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+    RAILS_ENV: production
+    RAILS_RELATIVE_URL_ROOT: "{{ redmine_relative_url_root }}"

--- a/site.yml
+++ b/site.yml
@@ -10,4 +10,4 @@
   post_tasks:
     - name: 完了
       debug:
-        msg='インストールが完了しました。 http://{{ ansible_default_ipv4.address }}/redmine/  にアクセスしてください。'
+        msg='インストールが完了しました。 http://{{ ansible_default_ipv4.address }}{{ redmine_relative_url_root }}/  にアクセスしてください。'


### PR DESCRIPTION
## 概要

Redmine 6.0 に対応した。

## 方針

* Redmine 6.0.0 でテーマのインストールディレクトリが `public/themes` から `themes` に変更されたことを対応する [^1] [^2] [^3] [^4]
* Redmine 6.0.0 で Propshaft が導入されたため、アプリケーションの起動時に `assets:precompile` が実行される際、環境変数が不足している場合を考慮し、明示的に`RAILS_RELATIVE_URL_ROOT` を指定して実行する [^5] [^6]
* https://github.com/farend/redmine-ubuntu-ansible/pull/15#issuecomment-2461064695 で報告のあった現象に遭遇したため、回避策として git 経由ではなくRedmine6.0対応のリリースを使用する
```
fatal: detected dubious ownership in repository at '/var/lib/redmine/themes/farend_basic'
To add an exception for this directory, call:

        git config --global --add safe.directory /var/lib/redmine/themes/farend_basic
```

## 確認したこと

- [x] VirtualBox上に 最小インストールの Ubuntu Server for ARM を用意して、Ansible を使って Redmine 6.0 を自動インストールできること
- [x] admin でログインでき、チケットに添付したPDFファイルのサムネイルが生成されること

<img width="888" alt="スクリーンショット 2024-11-15 10 25 26" src="https://github.com/user-attachments/assets/db5085ae-c5b3-4171-81dc-378ae4810251">

[^1]: https://www.redmine.org/news/147 にある `[breaking change]` の行や https://www.redmine.org/issues/41731 を一次情報源としています。
[^2]: https://redmine.jp/redmine_today/2024/11/redmine-6_0_0-released/
[^3]: https://blog.redmine.jp/articles/6_0/new-features/
[^4]: https://blog.redmine.jp/articles/6_0/checklist-themes-plugins-developer-before-redmine-6/
[^5]: https://www.redmine.org/issues/41734 や https://www.redmine.org/issues/41754 を一次情報源としています。
[^6]: https://github.com/redmine/redmine/blob/6.0.1/config/environments/production.rb#L97-L98 が `true` であるため、このAnsibleプレイブックのように `export RAILS_ENV=production` として rake タスクなどを実行すると、 [アプリケーションの初期化処理後](https://github.com/rails/propshaft/blob/v1.1.0/lib/propshaft/railtie.rb#L43) に [`Assembly.prepend` された無名モジュールにより、 `public/assets/.manifest.json` の変更有無が判断され、 `assets:precompile` が実行されます](https://github.com/redmine/redmine/blob/6.0.1/config/initializers/10-patches.rb#L122-L128) 。一方で、このAnsibleプレイブックと同様の構成（Apache + Passenger）においては、アプリケーション起動前に、`development` モードでのみ  rake タスクや rails コンソールを実行している状況であれば、アプリケーション起動時に `PassengerBaseURI` の値が  [`RAILS_RELATIVE_URL_ROOT` に設定された](https://github.com/phusion/passenger/blob/release-6.0.23/src/agent/SpawnEnvSetupper/SpawnEnvSetupperMain.cpp#L723-L726 )  `assets:precompile` が実行されるため、明示的に `assets:precompile` にする必要はありません。

