### PR TITLE
"Redmine.JP Blog - Redmine 6.0 をUbuntu 24.04 LTSにインストールする手順" に準拠する

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,23 @@
 
 最小構成でインストールしたUbuntu ServerにRedmineを自動インストールするためのAnsibleプレイブックです。
 
-コマンド6個実行するだけで、あとはしばらく放置すればインストールが完了します。
+`ansible-playbook` を実行するだけで、あとはしばらく放置すればインストールが完了します。
 
 
 ## 概要
 
 Ansibleを使ってRedmineを自動インストールするためのプレイブックです。以下のwebサイトで紹介されている手順におおむね準拠しています。
 
-[Redmine 5.1 をUbuntu 24.04 LTSにインストールする手順](https://blog.redmine.jp/articles/5_1/install/ubuntu24/)
+[Redmine 6.0 をUbuntu 24.04 LTSにインストールする手順](https://blog.redmine.jp/articles/6_0/install/ubuntu24/)
 
 ## システム構成
 
 * Ansible 2.17.5
 * Redmine 6.0
 * Ubuntu Server 24.04 LTS
-* PostgreSQL
-* Apache
+* PostgreSQL 16.4
+* Apache (Railsの実行にはPassengerを使用)
+* Ruby 3.3.6
 
 ## Redmineのインストール手順
 

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -25,8 +25,8 @@ redmine_db_user: redmine
 redmine_db_locale: ja_JP.UTF-8
 
 # ダウンロードするRubyのソースコード
-ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/3.2
-ruby_archive_version: ruby-3.2.4
+ruby_url_dir: https://cache.ruby-lang.org/pub/ruby/3.3
+ruby_archive_version: ruby-3.3.6
 ruby_archive_ext: tar.gz
 ruby_archive_name: "{{ ruby_archive_version }}.{{ ruby_archive_ext }}"
 

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -1,16 +1,19 @@
 # PostgreSQLでlc_collateとlc_ctypeに ja_JP.UTF-8 を指定するために必要
+# 海外業者のサーバなども考慮して念のために実行するもので、ロケール設定は変更しない
 - name: apt update
   become: yes
   apt:
     update_cache=yes
     cache_valid_time=86400
-- name: set locale to ja_JP.UTF-8 1/2
+- name: Generate ja_JP.UTF-8 locale 1/3
   become: yes
   apt:
-    name='locales'
-- name: set locale to ja_JP.UTF-8 2/2
+    name='language-pack-ja'
+- name: Generate ja_JP.UTF-8 locale 2/3
   become: yes
-  command: localectl set-locale LANG={{ redmine_db_locale }}
+  command: locale-gen ja_JP.UTF-8
+- name: Generate ja_JP.UTF-8 locale 3/3
+  shell: localectl list-locales | grep ja_JP.UTF-8
 
 # Redmine を動かすために必要なパッケージのインストール
 - name: RubyとPassengerのビルドに必要な開発ツールやヘッダファイルのインストール


### PR DESCRIPTION
## 概要

- 11月26日に公開された https://blog.redmine.jp/articles/6_0/install/ubuntu24/ の手順に準拠します。

## 方針

- Ruby 3.2.4 → 3.3.6 に更新する
- ロケール設定の変更までは不要なので、設定ファイルを生成するまでに変更する
- README を実態に合わせる（ https://github.com/farend/redmine-ubuntu-ansible/pull/16#discussion_r1857754100 を含む）
- テーマ「farend_basic」はデフォルトテーマに近くなっているが、そのままとする

## 確認したこと

- [x] VirtualBox上に 最小インストールの Ubuntu Server for ARM を用意して、Ansible を使って Redmine 6.0 を自動インストールできること
- [x] admin でログインでき、チケットに添付したPDFファイルのサムネイルが生成されること
- [x] [CI](https://github.com/maeda-m/redmine-ubuntu-ansible/actions/runs/12041672181) が成功すること

![スクリーンショット 2024-11-27 9 36 27](https://github.com/user-attachments/assets/13844a35-5645-43e4-9487-56a0219f494c)
